### PR TITLE
Add support for more `\begin` blocks

### DIFF
--- a/lib/math-to-itex.rb
+++ b/lib/math-to-itex.rb
@@ -23,8 +23,14 @@ module MathToItex
       elsif maths =~ /\A\\\[(?!\\\[)/
         just_maths = maths[2..-3]
         type = :display
-      elsif maths =~ /\A\\begin(?!\\begin)/
+      elsif maths =~ /\A\\begin{equation}(?!\\begin{equation})/
         just_maths = maths[16..-15]
+        type = :display
+      elsif maths =~ /\A\\begin{math}(?!\\begin{math})/
+        just_maths = maths[12..-11]
+        type = :inline
+      elsif maths =~ /\A\\begin{displaymath}(?!\\begin{displaymath})/
+        just_maths = maths[19..-18]
         type = :display
       end
 

--- a/lib/math-to-itex/parser.rb
+++ b/lib/math-to-itex/parser.rb
@@ -12,7 +12,7 @@ module MathToItex
         # group 3, match escaped bracket
         (\\\[)|
         # group 4, match begin equation
-        (\\begin\{equation\})
+        (\\begin\{(?:equation|math|displaymath)\})
     )
     (.*?(\g<1>)?.*?)  # match everything in between including nested LaTeX equations
     (?<!\\)  # negative look-behind to make sure end is not escaped
@@ -23,7 +23,7 @@ module MathToItex
         # if group 3 was start, escaped bracket is end
         (?(3)\\\]|
         # otherwise group 4 was start, match end equation
-        \\end\{equation\}
+        \\end\{(?:equation|math|displaymath)\}
     )))
     /xm
   end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -41,7 +41,7 @@ class MathToItex::BasicTest < Test::Unit::TestCase
     assert_equal 'Here we go: $$a \ne 0$$', result
   end
 
-  def test_it_matches_equation_notation
+  def test_it_matches_begin_equation_notation
     result = MathToItex('\begin{equation}x = {-b \pm \sqrt{b^2-4ac} \over 2a}\end{equation}').convert
 
     assert_equal '$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$', result
@@ -49,6 +49,16 @@ class MathToItex::BasicTest < Test::Unit::TestCase
     result = MathToItex('Here we go: \begin{equation}x = {-b \pm \sqrt{b^2-4ac} \over 2a}\end{equation}').convert { |s| s }
 
     assert_equal 'Here we go: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$', result
+  end
+
+  def test_it_matches_begin_math_notation
+    result = MathToItex('\begin{math}x = {-b \pm \sqrt{b^2-4ac} \over 2a}\end{math}').convert
+    assert_equal '$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$', result
+  end
+
+  def test_it_matches_begin_displaymath_notation
+    result = MathToItex('\begin{displaymath}x = {-b \pm \sqrt{b^2-4ac} \over 2a}\end{displaymath}').convert
+    assert_equal '$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$', result
   end
 
   def test_it_matches_multiple_lines


### PR DESCRIPTION
One can make LaTeX math with `\begin{math}` and `\begin{displaymath}` as well as the currently supported `\begin{equation}`. This adds support for the other mentioned `\begin` styles.