### PR TITLE
Expose math without extra characters

### DIFF
--- a/lib/math-to-itex.rb
+++ b/lib/math-to-itex.rb
@@ -30,14 +30,14 @@ module MathToItex
 
       # this is the format itex2MML expects
       if type == :inline
-        just_maths = "$#{just_maths}$"
+        all_maths = "$#{just_maths}$"
       else
-        just_maths = "$$#{just_maths}$$"
+        all_maths = "$$#{just_maths}$$"
       end
 
-      next(just_maths) if block.nil?
+      next(all_maths) if block.nil?
 
-      yield just_maths, type
+      yield all_maths, type, just_maths
     end
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -81,4 +81,12 @@ $$
 
     assert_equal '<span class="inline">$0$</span> is not equal to <span class="display">$$1 = 0$$</span>', result
   end
+
+  def test_it_can_return_plain_math
+    result = MathToItex('$0$ is not equal to $$1 = 0$$').convert do |string, type, just_maths|
+      %|<span class="#{type}" data-math="#{just_maths}">#{string}</span>|
+    end
+
+    assert_equal '<span class="inline" data-math="0">$0$</span> is not equal to <span class="display" data-math="1 = 0">$$1 = 0$$</span>', result
+  end
 end


### PR DESCRIPTION
This PR gives the user just the math section, without the surrounding `$` signs.

Is this ok? Should I expose this in a different method maybe?