### PR TITLE
Add some eqnarray support

### DIFF
--- a/lib/math-to-itex.rb
+++ b/lib/math-to-itex.rb
@@ -32,7 +32,7 @@ module MathToItex
       elsif maths =~ /\A\\begin{displaymath}(?!\\begin{displaymath})/
         just_maths = maths[19..-18]
         type = :display
-      elsif maths =~ /\A\\begin{eqnarray}(?!\\begin{eqnarray})/
+      elsif maths =~ /\A\\begin{#{MathToItex::Parser::JOINED_ENVIRONMENTS}}(?!\\begin{#{MathToItex::Parser::JOINED_ENVIRONMENTS}})/
         just_maths = maths
         type = :display
       end

--- a/lib/math-to-itex.rb
+++ b/lib/math-to-itex.rb
@@ -32,6 +32,9 @@ module MathToItex
       elsif maths =~ /\A\\begin{displaymath}(?!\\begin{displaymath})/
         just_maths = maths[19..-18]
         type = :display
+      elsif maths =~ /\A\\begin{eqnarray}(?!\\begin{eqnarray})/
+        just_maths = maths
+        type = :display
       end
 
       # this is the format itex2MML expects

--- a/lib/math-to-itex/parser.rb
+++ b/lib/math-to-itex/parser.rb
@@ -14,7 +14,7 @@ module MathToItex
         # group 3, match escaped bracket
         (\\\[)|
         # group 4, match begin equation
-        (\\begin\{(?:#{JOINED_ENVIRONMENTS})\})
+        \\begin\{(#{JOINED_ENVIRONMENTS})\}
     )
     (.*?(\g<1>)?.*?)  # match everything in between including nested LaTeX equations
     (?<!\\)  # negative look-behind to make sure end is not escaped
@@ -25,7 +25,7 @@ module MathToItex
         # if group 3 was start, escaped bracket is end
         (?(3)\\\]|
         # otherwise group 4 was start, match end equation
-        \\end\{(?:#{JOINED_ENVIRONMENTS})\}
+        \\end\{\4\}
     )))
     /xm
   end

--- a/lib/math-to-itex/parser.rb
+++ b/lib/math-to-itex/parser.rb
@@ -1,6 +1,6 @@
 module MathToItex
   class Parser
-    ENVIRONMENTS = %w(align align* alignat alignat* aligned alignedat array Bmatrix bmatrix cases displaymath eqnarray eqnarray* equation equation* gather gather* gathered math matrix multline multline* pmatrix smallmatrix split subarray svg Vmatrix vmatrix)
+    ENVIRONMENTS = %w(align align\* alignat alignat\* aligned alignedat array Bmatrix bmatrix cases displaymath eqnarray eqnarray\* equation equation\* gather gather\* gathered math matrix multline multline\* pmatrix smallmatrix split subarray svg Vmatrix vmatrix)
     JOINED_ENVIRONMENTS = ENVIRONMENTS.join('|')
     # https://stackoverflow.com/questions/14182879/regex-to-match-latex-equations
     REGEX = /

--- a/lib/math-to-itex/parser.rb
+++ b/lib/math-to-itex/parser.rb
@@ -1,5 +1,7 @@
 module MathToItex
   class Parser
+    ENVIRONMENTS = %w(align align* alignat alignat* aligned alignedat array Bmatrix bmatrix cases displaymath eqnarray eqnarray* equation equation* gather gather* gathered math matrix multline multline* pmatrix smallmatrix split subarray svg Vmatrix vmatrix)
+    JOINED_ENVIRONMENTS = ENVIRONMENTS.join('|')
     # https://stackoverflow.com/questions/14182879/regex-to-match-latex-equations
     REGEX = /
     (?<!\\)    # negative look-behind to make sure start is not escaped
@@ -12,7 +14,7 @@ module MathToItex
         # group 3, match escaped bracket
         (\\\[)|
         # group 4, match begin equation
-        (\\begin\{(?:equation|math|displaymath|eqnarray)\})
+        (\\begin\{(?:#{JOINED_ENVIRONMENTS})\})
     )
     (.*?(\g<1>)?.*?)  # match everything in between including nested LaTeX equations
     (?<!\\)  # negative look-behind to make sure end is not escaped
@@ -23,7 +25,7 @@ module MathToItex
         # if group 3 was start, escaped bracket is end
         (?(3)\\\]|
         # otherwise group 4 was start, match end equation
-        \\end\{(?:equation|math|displaymath|eqnarray)\}
+        \\end\{(?:#{JOINED_ENVIRONMENTS})\}
     )))
     /xm
   end

--- a/lib/math-to-itex/parser.rb
+++ b/lib/math-to-itex/parser.rb
@@ -12,7 +12,7 @@ module MathToItex
         # group 3, match escaped bracket
         (\\\[)|
         # group 4, match begin equation
-        (\\begin\{(?:equation|math|displaymath)\})
+        (\\begin\{(?:equation|math|displaymath|eqnarray)\})
     )
     (.*?(\g<1>)?.*?)  # match everything in between including nested LaTeX equations
     (?<!\\)  # negative look-behind to make sure end is not escaped
@@ -23,7 +23,7 @@ module MathToItex
         # if group 3 was start, escaped bracket is end
         (?(3)\\\]|
         # otherwise group 4 was start, match end equation
-        \\end\{(?:equation|math|displaymath)\}
+        \\end\{(?:equation|math|displaymath|eqnarray)\}
     )))
     /xm
   end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -65,6 +65,11 @@ class MathToItex::BasicTest < Test::Unit::TestCase
     assert_equal '$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$', result
   end
 
+  def test_it_matches_begin_eqnarray_notation
+    result = MathToItex('\begin{eqnarray}a &=& b\\\\b &=& c\end{eqnarray}').convert
+    assert_equal '$$\begin{eqnarray}a &=& b\\\\b &=& c\end{eqnarray}$$', result
+  end
+
   def test_it_matches_multiple_lines
     text = '''
 $$


### PR DESCRIPTION
A lil bit weird, but for compatibility with how Mathematical expects its `\begin{eqnarray}` blocks to behave.